### PR TITLE
Fixes bug where content wasn't auto-saving

### DIFF
--- a/app/assets/javascripts/textlab/views/xml-editor.js
+++ b/app/assets/javascripts/textlab/views/xml-editor.js
@@ -302,6 +302,11 @@ save: function(callback) {
 		}
 	};
 
+	// FIXME: This updates the model with the contents of the editor and THEN saves
+	// Leaving for now, but we should consider moving the model update to onchange so that any future functions
+	// which expect the model to be up to date don't fall through the autosave timing cracks
+	var doc = this.editor.getDoc();
+	this.model.set("content",doc.getValue());
 	this.model.save(null, {
 		success: onSuccess,
 		error: onError
@@ -573,8 +578,6 @@ initEditor: function() {
 		// Exit if change isn't paste
 		if (change.origin != "paste") return;
 		this.onClickRelink();
-
-
 
 	}, this));
 }


### PR DESCRIPTION
**What this does:**
PR 191 moved the pre-save handling code to paste and relink, accidentally removing the important bit where the model is updated from the editor. This restores the proper saving functionality.

**How to test:**
https://mel-textlab-pr-195.herokuapp.com/
Edit something, switch away, make sure the edit "sticks"
Check the share is working properly