### PR TITLE
TL #222 - Text display filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,6 @@ gem 'factory_bot_rails'
 
 # Docs
 gem 'sdoc', '~> 0.4.0', group: :doc
+
+# Environment variables
+gem 'dotenv-rails', groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,10 @@ GEM
       warden (~> 1.2.3)
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     ejs (1.1.1)
     erubis (2.7.0)
     exception_notification (4.2.2)
@@ -212,6 +216,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.5)
   devise
   devise-encryptable
+  dotenv-rails
   exception_notification
   factory_bot_rails
   font-awesome-sass
@@ -233,3 +238,9 @@ DEPENDENCIES
   therubyrhino
   uglifier (>= 1.3.0)
   underscore-rails
+
+RUBY VERSION
+   ruby 2.3.3p0 (jruby 9.1.12.0)
+
+BUNDLED WITH
+   1.16.4

--- a/app/views/transcriptions/show.html.erb
+++ b/app/views/transcriptions/show.html.erb
@@ -217,11 +217,9 @@ hr{
     _.each(facs, function(fac) {
       var fac_val = fac.attributes.facs.value;
       var zoneLabel = fac_val.slice( fac_val.length-4 );
-      if (irrelevant_zones.includes(zoneLabel)) {
-        fac.style.display = "none";
-      }
+
       if (relevant_zones.includes(zoneLabel)) {
-        fac.style.display = "inline";
+        fac.style.backgroundColor = "#FFFF00";
       }
     });
 


### PR DESCRIPTION
This pull request updates the transcription `show` page to highlight annotations for the selected stage, rather than show/hide.

**Stage 3**
![Screen Shot 2020-08-07 at 11 44 13 AM](https://user-images.githubusercontent.com/20641961/89664429-2b8bb100-d8a5-11ea-8dfa-aa31cae0123e.png)

**Stage 4**
![Screen Shot 2020-08-07 at 11 44 28 AM](https://user-images.githubusercontent.com/20641961/89664434-2dee0b00-d8a5-11ea-80f7-b89e9a54f296.png)

This pull request also adds the `dotenv-rails` gem to allow loading environment variables from a .env file.

**Note:** This pull request will be merged into the `stage_iteratives` branch.