### PR TITLE
TL #235 - Base tab highlights

### DIFF
--- a/app/views/transcriptions/show.html.erb
+++ b/app/views/transcriptions/show.html.erb
@@ -212,12 +212,12 @@ hr{
       model: <%=raw @leaf.to_json %>
   });
     leafViewer.render();
-    var facs = $('[facs]').get();
+    var facs = $('#diplo-pane').find('[facs]').get();
 
     _.each(facs, function(fac) {
       var fac_val = fac.attributes.facs.value;
       var zoneLabel = fac_val.slice( fac_val.length-4 );
-
+      
       if (relevant_zones.includes(zoneLabel)) {
         fac.style.backgroundColor = "#FFFF00";
       }


### PR DESCRIPTION
This pull request updates the transcriptions show page to only highlight edits on the "Diplomatic" tab (not the "Base" tab).

**Diplomatic tab**
![Screen Shot 2020-08-20 at 9 06 34 AM](https://user-images.githubusercontent.com/20641961/90773900-9d5ff380-e2c4-11ea-88b3-a5e5911447ad.png)

**Base tab**
![Screen Shot 2020-08-20 at 9 06 43 AM](https://user-images.githubusercontent.com/20641961/90773906-9f29b700-e2c4-11ea-962a-78804db3a2e3.png)
