### PR TITLE
Release phase

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+release: bin/rake db:migrate


### PR DESCRIPTION
This pull request adds the `release` phase to the `Procfile` to automatically run migrations during deployment. This way, there will be no timespan where the application has been deployed, but the migrations have not been run, leaving it in an unusable state.