### PR TITLE
TL #248 - Preview button error

### DIFF
--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -32,6 +32,7 @@ class Transcription < ActiveRecord::Base
     zones_hash = {}
     %w(metamark add del subst restore).each do |attrs|
       fragment.xpath("//#{attrs}").each do |mark|
+        next unless mark.attributes["facs"].present?
         zone = mark.attributes["facs"].value.split("-").last
         unless zones_hash.keys.include?(zone)
           temp_hash = {

--- a/app/views/transcriptions/show.html.erb
+++ b/app/views/transcriptions/show.html.erb
@@ -4,8 +4,7 @@
 
       <div class='nav nav-actions'>
         <% unless @prev_leaf.nil? %>
-          <a class="prev-leaf-button" 
-          ef="<%= url_for @prev_leaf %>"><i class='fa fa-chevron-circle-left'></i> Previous Leaf</a>
+          <a class="prev-leaf-button" href="<%= url_for @prev_leaf %>"><i class='fa fa-chevron-circle-left'></i> Previous Leaf</a>
         <% end %>
         <% unless @next_leaf.nil? %>
           <a class="next-leaf-button" href="<%= url_for @next_leaf %>">Next Leaf <i class='fa fa-chevron-circle-right'></i></a>


### PR DESCRIPTION
This pull request fixes an issue with the Previous/Next buttons on the Textlab preview page. There was an exception being thrown in `transcription.rb` if the content of the transcription did not contain one of the following TEI elements: `metamark add del subst restore`. Additionally, there was a typo in the transcriptions/show.html.erb file, where the `href` attribute for the Previous button was not present, making the button not usable.