### PR TITLE
TL #245 - Leaf edit error

### DIFF
--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -76,7 +76,7 @@ class Transcription < ActiveRecord::Base
       published: self.published,
       next_zone_label: self.next_zone_label,
       owner: owner,
-      owner_name: self.user.display_name,
+      owner_name: self.user&.display_name,
       zone_hash: zones_hash,
       zones: self.zones.map{ |z| z.obj }
     }


### PR DESCRIPTION
This pull request fixes a bug that occurred when editing Leaf 17 of Billy Budd (Document ID 121). The editor pane would not load because the API request for the transcriptions records was throwing an exception. The exception was caused by a transcription record with no `user_id`. The `user_id` attribute is set when the transcription is created, so I'm not 100% sure how this happened. There are only 16 transcription records with no `user_id`, all created on 11/22/2017 within a couple minutes of each other. Perhaps a bug that existed at the time?

![Screen Shot 2021-01-04 at 8 12 14 AM](https://user-images.githubusercontent.com/20641961/103539100-723a0300-4e65-11eb-8a24-86780b83ada2.png)
